### PR TITLE
Tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         if: matrix.os == 'macOS-latest'
         run: |
           brew install shfmt shellcheck
-          shfmt -d .
+          shfmt -d install.sh
       - name: tests shell
         if: matrix.os != 'windows-latest'
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,17 +19,17 @@ jobs:
         run: |
           brew install shfmt shellcheck
           shfmt -d install.sh
-      - name: tests shell
+
+      - name: test shell
         if: matrix.os != 'windows-latest'
         shell: bash
         run: ./test/install_test.sh
 
-      - name: tests powershell
-        if: matrix.os == 'windows-latest'
-        shell: powershell
+      - name: test powershell core
+        shell: pwsh
         run: ./test/install_test.ps1
 
-      - name: tests powershell core
+      - name: test windows powershell
         if: matrix.os == 'windows-latest'
-        shell: pwsh
+        shell: powershell
         run: ./test/install_test.ps1

--- a/install.ps1
+++ b/install.ps1
@@ -111,7 +111,8 @@ if ($needInstallToken) {
 }
 Write-Output ""
 
-if ($installCall.ExitCode -ne 0 -Or $wrapCall.ExitCode -ne 0 -Or $authCall.ExitCode -ne 0) {
+$authSuccess = ($authCall.ExitCode -eq 0) -Or !$needInstallToken
+if ($installCall.ExitCode -ne 0 -Or $wrapCall.ExitCode -ne 0 -Or !$authSuccess) {
   Write-Output ""
   Write-Output "Oh no :( we had trouble setting up Flossbank. Please try again or email support@flossbank.com for help!"
   return

--- a/install.ps1
+++ b/install.ps1
@@ -79,8 +79,8 @@ if (!$Response) {
 }
 $FlossbankAssetInfo = $Response.Content
 
-$FlossbankUri = $FlossbankAssetInfo.Split([Environment]::NewLine)[0]
-$FlossbankVersion = $FlossbankAssetInfo.Split([Environment]::NewLine)[1]
+$FlossbankUri = $FlossbankAssetInfo.Split("`n")[0]
+$FlossbankVersion = $FlossbankAssetInfo.Split("`n")[1]
 $FlossbankFileName = $FlossbankUri.Split("/")[8]
 
 if (!(Test-Path $BinDir)) {

--- a/install.ps1
+++ b/install.ps1
@@ -22,7 +22,7 @@ $ErrorActionPreference = 'Stop'
 
 $FlossbankInstall = $env:FLOSSBANK_INSTALL
 if (!$FlossbankInstall) {
-  $FlossbankInstall = Join-Path $Home ".flossbank"
+  $FlossbankInstall = Join-Path -Path "$Home" -ChildPath ".flossbank"
 }
 
 if ($PSVersionTable.PSEdition -ne 'Core' -Or $IsWindows) {
@@ -39,9 +39,9 @@ if ($PSVersionTable.PSEdition -ne 'Core' -Or $IsWindows) {
   }
 }
 
-$BinDir = Join-Path $FlossbankInstall "bin"
-$FlossbankZip = Join-Path $BinDir "flossbank.zip"
-$FlossbankExe = Join-Path $BinDir $ExeName
+$BinDir = Join-Path -Path "$FlossbankInstall" -ChildPath "bin"
+$FlossbankZip = Join-Path -Path "$BinDir" -ChildPath "flossbank.zip"
+$FlossbankExe = Join-Path -Path "$BinDir" -ChildPath "$ExeName"
 
 $FlossbankInstallToken = $env:FLOSSBANK_INSTALL_TOKEN
 if (!(Test-Path $FlossbankExe)) {
@@ -118,7 +118,7 @@ if ($installCall.ExitCode -ne 0 -Or $wrapCall.ExitCode -ne 0 -Or !$authSuccess) 
   return
 }
 
-$envFile = Join-Path $FlossbankInstall "env.ps1"
+$envFile = Join-Path -Path "$FlossbankInstall" -ChildPath "env.ps1"
 . $envFile
 
 Write-Output ""

--- a/test/install_test.ps1
+++ b/test/install_test.ps1
@@ -3,12 +3,24 @@
 $ErrorActionPreference = 'Stop'
 
 # set staging api endpoint so we can use bogus install token
+$LinuxConfigPath = if ($XDG_CONFIG_HOME) {
+  Join-Path $XDG_CONFIG_HOME ".config" "flossbank-nodejs"
+} else {
+  Join-Path $Home ".config" "flossbank-nodejs"
+}
+$MacConfigPath = Join-Path $Home "Library" "Preferences" "flossbank-nodejs"
 $WinConfigPath = Join-Path $Home "AppData" "Roaming" "flossbank-nodejs" "Config"
-New-Item $WinConfigPath -ItemType Directory
+New-Item $LinuxConfigPath -ItemType Directory | Out-Null
+New-Item $MacConfigPath -ItemType Directory | Out-Null
+New-Item $WinConfigPath -ItemType Directory | Out-Null
+$LinuxConfig = Join-Path $LinuxConfigPath "config.json"
+$MacConfig = Join-Path $MacConfigPath "config.json"
 $WinConfig = Join-Path $WinConfigPath "config.json"
+Write-Output '{"apiHost":"https://api.flossbank.io"}' > $LinuxConfig
+Write-Output '{"apiHost":"https://api.flossbank.io"}' > $MacConfig
 Write-Output '{"apiHost":"https://api.flossbank.io"}' > $WinConfig
 
-$FLOSSBANK_INSTALL_TOKEN = "cf667c9381f7792bfa772025ff8ee93b89d9a757e6732e87611a0c34b48357d1"
+$env:FLOSSBANK_INSTALL_TOKEN = "cf667c9381f7792bfa772025ff8ee93b89d9a757e6732e87611a0c34b48357d1"
 
 # install the latest version at the default location
 $DefaultLocation = Join-Path $Home ".flossbank"

--- a/test/install_test.ps1
+++ b/test/install_test.ps1
@@ -27,7 +27,7 @@ $DefaultLocation = Join-Path $Home ".flossbank"
 if (Test-Path $DefaultLocation) {
   Remove-Item -Force -Recurse $DefaultLocation
 }
-$FLOSSBANK_INSTALL = ""
+$env:FLOSSBANK_INSTALL = ""
 .\install.ps1
 $Exe = Join-Path $DefaultLocation "bin" "flossbank"
 Start-Process $Exe -Wait -NoNewWindow -PassThru
@@ -37,7 +37,7 @@ $CustomLocation = Join-Path $Home "flossbank-custom"
 if (Test-Path $CustomLocation) {
   Remove-Item -Force -Recurse $CustomLocation
 }
-$FLOSSBANK_INSTALL = $CustomLocation
+$env:FLOSSBANK_INSTALL = $CustomLocation
 .\install.ps1
 $Exe = Join-Path $CustomLocation "bin" "flossbank"
 Start-Process $Exe -Wait -NoNewWindow -PassThru

--- a/test/install_test.ps1
+++ b/test/install_test.ps1
@@ -24,7 +24,7 @@ $env:FLOSSBANK_INSTALL_TOKEN = "cf667c9381f7792bfa772025ff8ee93b89d9a757e6732e87
 
 # install the latest version at the default location
 $DefaultLocation = Join-Path $Home ".flossbank"
-if (!(Test-Path $DefaultLocation)) {
+if (Test-Path $DefaultLocation) {
   Remove-Item -Force -Recurse $DefaultLocation
 }
 $FLOSSBANK_INSTALL = ""
@@ -34,7 +34,7 @@ Start-Process $Exe -Wait -NoNewWindow -PassThru
 
 # install to a custom location
 $CustomLocation = Join-Path $Home "flossbank-custom"
-if (!(Test-Path $CustomLocation)) {
+if (Test-Path $CustomLocation) {
   Remove-Item -Force -Recurse $CustomLocation
 }
 $FLOSSBANK_INSTALL = $CustomLocation

--- a/test/install_test.ps1
+++ b/test/install_test.ps1
@@ -10,9 +10,9 @@ $LinuxConfigPath = if ($XDG_CONFIG_HOME) {
 }
 $MacConfigPath = Join-Path $Home "Library" "Preferences" "flossbank-nodejs"
 $WinConfigPath = Join-Path $Home "AppData" "Roaming" "flossbank-nodejs" "Config"
-New-Item $LinuxConfigPath -ItemType Directory | Out-Null
-New-Item $MacConfigPath -ItemType Directory | Out-Null
-New-Item $WinConfigPath -ItemType Directory | Out-Null
+New-Item $LinuxConfigPath -Force -ItemType Directory | Out-Null
+New-Item $MacConfigPath -Force -ItemType Directory | Out-Null
+New-Item $WinConfigPath -Force -ItemType Directory | Out-Null
 $LinuxConfig = Join-Path $LinuxConfigPath "config.json"
 $MacConfig = Join-Path $MacConfigPath "config.json"
 $WinConfig = Join-Path $WinConfigPath "config.json"

--- a/test/install_test.ps1
+++ b/test/install_test.ps1
@@ -2,4 +2,26 @@
 
 $ErrorActionPreference = 'Stop'
 
-Write-Output "Testing"
+# set staging api endpoint so we can use bogus install token
+$WinConfigPath = Join-Path $Home "AppData" "Roaming" "flossbank-nodejs" "Config"
+New-Item $WinConfigPath -ItemType Directory
+$WinConfig = Join-Path $WinConfigPath "config.json"
+Write-Output '{"apiHost":"https://api.flossbank.io"}' > $WinConfig
+
+$FLOSSBANK_INSTALL_TOKEN = "cf667c9381f7792bfa772025ff8ee93b89d9a757e6732e87611a0c34b48357d1"
+
+# install the latest version at the default location
+$DefaultLocation = Join-Path $Home ".flossbank"
+Remove-Item -Force -Recurse $DefaultLocation
+$FLOSSBANK_INSTALL = ""
+.\install.ps1
+$Exe = Join-Path $DefaultLocation "bin" "flossbank"
+Start-Process $Exe -Wait -NoNewWindow -PassThru
+
+# install to a custom location
+$CustomLocation = Join-Path $Home "flossbank-custom"
+Remove-Item -Force -Recurse $CustomLocation
+$FLOSSBANK_INSTALL = $CustomLocation
+.\install.ps1
+$Exe = Join-Path $CustomLocation "bin" "flossbank"
+Start-Process $Exe -Wait -NoNewWindow -PassThru

--- a/test/install_test.ps1
+++ b/test/install_test.ps1
@@ -24,7 +24,9 @@ $env:FLOSSBANK_INSTALL_TOKEN = "cf667c9381f7792bfa772025ff8ee93b89d9a757e6732e87
 
 # install the latest version at the default location
 $DefaultLocation = Join-Path $Home ".flossbank"
-Remove-Item -Force -Recurse $DefaultLocation
+if (!(Test-Path $DefaultLocation)) {
+  Remove-Item -Force -Recurse $DefaultLocation
+}
 $FLOSSBANK_INSTALL = ""
 .\install.ps1
 $Exe = Join-Path $DefaultLocation "bin" "flossbank"
@@ -32,7 +34,9 @@ Start-Process $Exe -Wait -NoNewWindow -PassThru
 
 # install to a custom location
 $CustomLocation = Join-Path $Home "flossbank-custom"
-Remove-Item -Force -Recurse $CustomLocation
+if (!(Test-Path $CustomLocation)) {
+  Remove-Item -Force -Recurse $CustomLocation
+}
 $FLOSSBANK_INSTALL = $CustomLocation
 .\install.ps1
 $Exe = Join-Path $CustomLocation "bin" "flossbank"

--- a/test/install_test.ps1
+++ b/test/install_test.ps1
@@ -3,19 +3,19 @@
 $ErrorActionPreference = 'Stop'
 
 # set staging api endpoint so we can use bogus install token
-$LinuxConfigPath = if ($XDG_CONFIG_HOME) {
-  Join-Path $XDG_CONFIG_HOME ".config" "flossbank-nodejs"
+$LinuxConfigPath = if ($env:XDG_CONFIG_HOME) {
+  Join-Path -Path "$env:XDG_CONFIG_HOME" -ChildPath ".config" | Join-Path -ChildPath "flossbank-nodejs"
 } else {
-  Join-Path $Home ".config" "flossbank-nodejs"
+  Join-Path -Path "$Home" -ChildPath ".config" | Join-Path -ChildPath "flossbank-nodejs"
 }
-$MacConfigPath = Join-Path $Home "Library" "Preferences" "flossbank-nodejs"
-$WinConfigPath = Join-Path $Home "AppData" "Roaming" "flossbank-nodejs" "Config"
+$MacConfigPath = Join-Path -Path "$Home" -ChildPath "Library" | Join-Path -ChildPath "Preferences" | Join-Path -ChildPath "flossbank-nodejs"
+$WinConfigPath = Join-Path -Path "$Home" -ChildPath "AppData" | Join-Path -ChildPath "Roaming" | Join-Path -ChildPath "flossbank-nodejs" | Join-Path -ChildPath "Config"
 New-Item $LinuxConfigPath -Force -ItemType Directory | Out-Null
 New-Item $MacConfigPath -Force -ItemType Directory | Out-Null
 New-Item $WinConfigPath -Force -ItemType Directory | Out-Null
-$LinuxConfig = Join-Path $LinuxConfigPath "config.json"
-$MacConfig = Join-Path $MacConfigPath "config.json"
-$WinConfig = Join-Path $WinConfigPath "config.json"
+$LinuxConfig = Join-Path -Path "$LinuxConfigPath" -ChildPath "config.json"
+$MacConfig = Join-Path -Path "$MacConfigPath" -ChildPath "config.json"
+$WinConfig = Join-Path -Path "$WinConfigPath" -ChildPath "config.json"
 Write-Output '{"apiHost":"https://api.flossbank.io"}' > $LinuxConfig
 Write-Output '{"apiHost":"https://api.flossbank.io"}' > $MacConfig
 Write-Output '{"apiHost":"https://api.flossbank.io"}' > $WinConfig
@@ -29,7 +29,7 @@ if (Test-Path $DefaultLocation) {
 }
 $env:FLOSSBANK_INSTALL = ""
 .\install.ps1
-$Exe = Join-Path $DefaultLocation "bin" "flossbank"
+$Exe = Join-Path -Path $DefaultLocation -ChildPath "bin" | Join-Path -ChildPath "flossbank"
 Start-Process $Exe -Wait -NoNewWindow -PassThru
 
 # install to a custom location
@@ -39,5 +39,5 @@ if (Test-Path $CustomLocation) {
 }
 $env:FLOSSBANK_INSTALL = $CustomLocation
 .\install.ps1
-$Exe = Join-Path $CustomLocation "bin" "flossbank"
+$Exe = Join-Path -Path $CustomLocation -ChildPath "bin" | Join-Path -ChildPath "flossbank"
 Start-Process $Exe -Wait -NoNewWindow -PassThru

--- a/test/install_test.sh
+++ b/test/install_test.sh
@@ -8,8 +8,8 @@ shellcheck -s bash ./install.sh
 # set staging api endpoint so we can use bogus install token
 MACOS_CONFIG="$HOME/Library/Preferences/flossbank-nodejs"
 LINUX_CONFIG="${XDG_CONFIG_HOME:-$HOME}/.config/flossbank-nodejs"
-mkdir -p MACOS_CONFIG
-mkdir -p LINUX_CONFIG
+mkdir -p "$MACOS_CONFIG"
+mkdir -p "$LINUX_CONFIG"
 echo '{"apiHost":"https://api.flossbank.io"}' > "$MACOS_CONFIG/config.json"
 echo '{"apiHost":"https://api.flossbank.io"}' > "$LINUX_CONFIG/config.json"
 

--- a/test/install_test.sh
+++ b/test/install_test.sh
@@ -3,7 +3,7 @@
 set -e
 
 # lint
-shellcheck -s bash ../install.sh
+shellcheck -s bash ./install.sh
 
 # set staging api endpoint so we can use bogus install token
 MACOS_CONFIG="$HOME/Library/Preferences/flossbank-nodejs"

--- a/test/install_test.sh
+++ b/test/install_test.sh
@@ -1,5 +1,28 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-echo "Testing"
+# lint
+shellcheck -s bash ../install.sh
+
+# set staging api endpoint so we can use bogus install token
+MACOS_CONFIG="$HOME/Library/Preferences/flossbank-nodejs"
+LINUX_CONFIG="${XDG_CONFIG_HOME:-$HOME}/.config/flossbank-nodejs"
+mkdir -p MACOS_CONFIG
+mkdir -p LINUX_CONFIG
+echo '{"apiHost":"https://api.flossbank.io"}' > "$MACOS_CONFIG/config.json"
+echo '{"apiHost":"https://api.flossbank.io"}' > "$LINUX_CONFIG/config.json"
+
+export FLOSSBANK_INSTALL_TOKEN="cf667c9381f7792bfa772025ff8ee93b89d9a757e6732e87611a0c34b48357d1"
+
+# install the latest version at the default location
+rm -f ~/.flossbank/bin/flossbank
+unset FLOSSBANK_INSTALL
+bash ./install.sh
+~/.flossbank/bin/flossbank --version
+
+# install to a custom location
+rm -rf ~/flossbank-custom
+export FLOSSBANK_INSTALL="$HOME/flossbank-custom"
+bash ./install.sh
+~/flossbank-custom/bin/flossbank --version


### PR DESCRIPTION
Adds CI tests
- linux and mac run shell installer as well as powershell (pwsh) installer
- windows runs powershell installer in pwsh and windows powershell
- found a bunch of bugs in powershell installer due to compatibility issues between pwsh and wp; fixed them

assertions aren't made as to the state of shell profiles/package managers after install; the install script outsources that functionality to the CLI so the testing lives there as well.